### PR TITLE
fix: 분류 별 질문 갯수 추가

### DIFF
--- a/src/main/kotlin/com/tik/server/dto/InterviewCreateRequest.kt
+++ b/src/main/kotlin/com/tik/server/dto/InterviewCreateRequest.kt
@@ -17,6 +17,8 @@ class InterviewCreateRequest {
         private set
 
     class Option (
-        var questionCount: Int
+        var resumeQuestion: Int,
+        var jdQuestion: Int,
+        var csQuestion: Int
     )
 }

--- a/src/main/kotlin/com/tik/server/entity/InterviewHistory.kt
+++ b/src/main/kotlin/com/tik/server/entity/InterviewHistory.kt
@@ -12,7 +12,13 @@ class InterviewHistory(
     @Column(name = "job_description")
     var jobDescription: String,
     @Column(name = "company")
-    var company: String
+    var company: String,
+    @Column(name = "resume_question")
+    var resumeQuestion: Int,
+    @Column(name = "jd_question")
+    var jdQuestion: Int,
+    @Column(name = "cs_question")
+    var csQuestion: Int
 ) : BaseTimeEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/kotlin/com/tik/server/service/InterviewService.kt
+++ b/src/main/kotlin/com/tik/server/service/InterviewService.kt
@@ -35,7 +35,10 @@ class InterviewService(
                 InterviewHistory(
                     resume = resume,
                     jobDescription = request.jobDescription,
-                    company = request.company
+                    company = request.company,
+                    resumeQuestion = request.options.resumeQuestion,
+                    jdQuestion = request.options.jdQuestion,
+                    csQuestion = request.options.csQuestion
                 )
             )
         }
@@ -46,9 +49,9 @@ class InterviewService(
                 techStack = arrayListOf(techStack),
                 jobDescription = arrayListOf(request.jobDescription),
                 options = LlmClient.InitInterview.Options(
-                    resumeQuestion = request.options.questionCount, // TODO: 갯수 수정
-                    jdQuestion = request.options.questionCount,
-                    csQuestion = request.options.questionCount,
+                    resumeQuestion = request.options.resumeQuestion,
+                    jdQuestion = request.options.jdQuestion,
+                    csQuestion = request.options.csQuestion
                 )
             )
         )


### PR DESCRIPTION
### 내용
- interview init 시 이력서/JD/CS 개수 body에 받도록 수정
- interview history에 질문 개수 필드 추가